### PR TITLE
Fix critical shell-quote vulnerability (GHSA-w7jw-789q-3m8p)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10315,10 +10315,14 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "license": "MIT",
   "overrides": {
-    "qs": "^6.15.2"
+    "qs": "^6.15.2",
+    "shell-quote": "^1.8.4"
   },
   "dependencies": {
     "@actions/artifact": "^6.2.1",


### PR DESCRIPTION
## Summary

Resolves the open **critical** Dependabot alert [#79](https://github.com/gradle/develocity-actions/security/dependabot/79) for [`shell-quote` (GHSA-w7jw-789q-3m8p)](https://github.com/advisories/GHSA-w7jw-789q-3m8p) — *`quote()` does not escape newlines in object `.op` values*.

`shell-quote@1.8.1` was pulled in transitively (dev scope) via `npm-run-all`:

```
github-actions@1.0.0
└─┬ npm-run-all@4.1.5
  └── shell-quote@1.8.1   (vulnerable: >= 1.1.0, <= 1.8.3)
```

`npm-run-all` is unmaintained and still pins `shell-quote ^1.6.1`, so this adds a top-level `overrides` entry forcing the first patched version, `^1.8.4`. This matches the existing pattern already used for `qs`.

## Verification

- `npm install` resolves `shell-quote@1.8.4`
- `npm audit` reports **0 vulnerabilities**
- `npm run check` (driven by `npm-run-all`) passes

Only `package.json` / `package-lock.json` change — a dev-tooling dependency — so no `dist/` rebuild is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)