### PR TITLE
Update Develocity docs link to docs.develocity.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
 ```
 
 > [!NOTE]
-> When authenticated access is required to publish a Build Scan®, it is recommended to provide as input `develocity-access-key` to the `setup-maven` and/or `setup-npm` steps. This triggers a request for a [short-lived access token](https://docs.gradle.com/develocity/current/reference/develocity-api/#short-lived-access-tokens) instead of relying on the `DEVELOCITY_ACCESS_KEY` environment variable.
+> When authenticated access is required to publish a Build Scan®, it is recommended to provide as input `develocity-access-key` to the `setup-maven` and/or `setup-npm` steps. This triggers a request for a [short-lived access token](https://docs.develocity.ai/current/reference/develocity-api/#short-lived-access-tokens) instead of relying on the `DEVELOCITY_ACCESS_KEY` environment variable.
 
 ---
 


### PR DESCRIPTION
Point the short-lived access token documentation link at the canonical docs domain `docs.develocity.ai` instead of the legacy `docs.gradle.com/develocity` path.

`docs.gradle.com/develocity/…` now issues a 301 to `docs.develocity.ai/…`; this links directly to the destination. No content change — same page, same anchor.