### PR TITLE
Fix npm vulnerabilities in undici, brace-expansion and js-yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "eslint-plugin-jsonc": "^2.16.0",
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "^30.4.2",
-        "js-yaml": "^5.2.1",
+        "js-yaml": "^5.2.2",
         "nock": "^14.0.17",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.9.6",
@@ -3554,15 +3554,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -7883,9 +7883,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
       "dev": true,
       "funding": [
         {
@@ -11243,9 +11243,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
   "overrides": {
     "qs": "^6.15.2",
     "shell-quote": "^1.10.0",
-    "brace-expansion": "^5.0.7",
-    "undici": "^6.27.0",
+    "brace-expansion": "^5.0.9",
+    "undici": "^6.28.0",
     "@babel/core": "^7.29.6",
-    "js-yaml": "^5.2.1"
+    "js-yaml": "^5.2.2"
   },
   "dependencies": {
     "@actions/artifact": "^6.2.1",
@@ -69,7 +69,7 @@
     "eslint-plugin-jsonc": "^2.16.0",
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^30.4.2",
-    "js-yaml": "^5.2.1",
+    "js-yaml": "^5.2.2",
     "nock": "^14.0.17",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.9.6",


### PR DESCRIPTION
Closes the six open Dependabot alerts on `package-lock.json`. All three packages are transitive dependencies already pinned by top-level `overrides`, so each override is bumped to the first patched version:

| Package | From | To | Alerts fixed |
|---|---|---|---|
| `undici` | 6.27.0 | `^6.28.0` | cookie attribute injection via unsanitized domain (medium), downstream response desynchronization via retry interceptor (medium), CRLF injection via blob-like body `type` (medium) |
| `brace-expansion` | 5.0.7 | `^5.0.9` | DoS via unbounded expansion length causing an OOM crash (high), DoS via unbounded intermediate arrays bypassing the CVE-2026-14257 mitigation (high) |
| `js-yaml` | 5.2.1 | `^5.2.2` | exponential parsing time in flow collections leads to DoS (high) |

`js-yaml` is also a direct devDependency, so its dependency spec is bumped alongside the override — npm requires the two to match. It resolves to 5.2.3.

## Verification

- Lockfile resolves `brace-expansion` 5.0.9, `undici` 6.28.0, `js-yaml` 5.2.3 — one copy of each, no vulnerable duplicates left in the tree
- `npm audit` reports 0 vulnerabilities
- `npm test` passes (8 suites, 33 tests)

`dist/` is intentionally untouched — the `update-dist` workflow regenerates it on merge to main, matching the precedent in #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)