### PR TITLE
Relax Develocity access key format validation

### DIFF
--- a/build-scan-shared/__tests__/auth/auth.test.ts
+++ b/build-scan-shared/__tests__/auth/auth.test.ts
@@ -39,6 +39,23 @@ describe('auth', () => {
         expect(accessToken).toBe('dev=token1')
     })
 
+    it('Get access key with short-lived token succeeds when the access key holds an OIDC token', async () => {
+        // given
+        const oidcToken = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJyZXBvOmZvby9iYXIifQ.c2lnbmF0dXJl_-=='
+        const develocityAccessKeyFromInput = `dev=${oidcToken}`
+        const develocityTokenExpiryFromInput = ''
+        nock('https://dev')
+            .matchHeader('Authorization', `Bearer ${oidcToken}`)
+            .post('/api/auth/token')
+            .reply(200, 'token1')
+
+        // when
+        const accessToken = await auth.getAccessToken(develocityAccessKeyFromInput, develocityTokenExpiryFromInput)
+
+        // then
+        expect(accessToken).toBe('dev=token1')
+    })
+
     it('Fall back to Develocity access key when short-lived token retrieval fails', async () => {
         // given
         const develocityAccessKeyFromInput = 'dev=key1'

--- a/build-scan-shared/__tests__/auth/short-lived-token.test.ts
+++ b/build-scan-shared/__tests__/auth/short-lived-token.test.ts
@@ -1,0 +1,147 @@
+import {jest} from '@jest/globals'
+
+import {DevelocityAccessCredentials} from '../../src/auth/short-lived-token'
+
+describe('access key parsing', () => {
+    it('parse valid access key should return an object', async () => {
+        // when
+        const develocityAccessCredentials = DevelocityAccessCredentials.parse('some-host.local=key1;host2=key2')
+
+        // then
+        expect(develocityAccessCredentials).toStrictEqual(
+            DevelocityAccessCredentials.of([
+                {hostname: 'some-host.local', key: 'key1'},
+                {hostname: 'host2', key: 'key2'}
+            ])
+        )
+    })
+
+    it('parse access key with an OIDC token value should return an object', async () => {
+        // given
+        const oidcToken = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJyZXBvOmZvby9iYXI_-x=.c2lnbmF0dXJl=='
+
+        // when
+        const develocityAccessCredentials = DevelocityAccessCredentials.parse(`some-host.local=${oidcToken}`)
+
+        // then
+        expect(develocityAccessCredentials).toStrictEqual(
+            DevelocityAccessCredentials.of([{hostname: 'some-host.local', key: oidcToken}])
+        )
+    })
+
+    it('parse access key splits each entry on the first separator only', async () => {
+        // when
+        const develocityAccessCredentials = DevelocityAccessCredentials.parse('host1=a=b==;host2=c=d')
+
+        // then
+        expect(develocityAccessCredentials).toStrictEqual(
+            DevelocityAccessCredentials.of([
+                {hostname: 'host1', key: 'a=b=='},
+                {hostname: 'host2', key: 'c=d'}
+            ])
+        )
+    })
+
+    it('parse access key tolerates surrounding whitespace', async () => {
+        // when
+        const develocityAccessCredentials = DevelocityAccessCredentials.parse(' host1=key1\n')
+
+        // then
+        expect(develocityAccessCredentials).toStrictEqual(
+            DevelocityAccessCredentials.of([{hostname: 'host1', key: 'key1'}])
+        )
+    })
+
+    it('access key with an OIDC token value as raw string', async () => {
+        // given
+        const rawKey = 'host1=eyJhbGciOiJSUzI1NiJ9.payload.signature==;host2=key2'
+
+        // when
+        const develocityAccessCredentials = DevelocityAccessCredentials.parse(rawKey)
+
+        // then
+        expect(develocityAccessCredentials?.raw()).toBe(rawKey)
+    })
+
+    it.each([
+        ['empty', ''],
+        ['blank', '  '],
+        ['no separator', 'host1'],
+        ['a trailing separator', 'host1=key1;'],
+        ['a leading separator', ';host1=key1'],
+        ['an empty hostname', '=key1'],
+        ['an empty key', 'host1='],
+        ['whitespace in the hostname', 'ho st1=key1'],
+        ['whitespace in the key', 'host1=ke y1'],
+        ['whitespace around a separator', 'host1=key1; host2=key2'],
+        ['one invalid entry', 'host1=key1;random']
+    ])('parse access key with %s should return null', async (_description, rawKey) => {
+        // expect
+        expect(DevelocityAccessCredentials.parse(rawKey)).toBeNull()
+    })
+})
+
+describe('access key format warnings', () => {
+    // `core.warning` is an ESM export and cannot be spied on, so capture the workflow command it
+    // writes to stdout instead.
+    let stdout: jest.SpiedFunction<typeof process.stdout.write>
+
+    const warnings = (): string[] =>
+        stdout.mock.calls
+            .map(call => String(call[0]))
+            .filter(line => line.startsWith('::warning::'))
+            .map(line => line.substring('::warning::'.length).trim())
+
+    beforeEach(() => {
+        stdout = jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    })
+
+    afterEach(() => {
+        stdout.mockRestore()
+    })
+
+    it.each([
+        ['no separator', 'host1', "no '=' separator in the value"],
+        ['a trailing separator', 'host1=key1;', "no '=' separator in entry 2 of 2"],
+        ['a leading separator', ';host1=key1', "no '=' separator in entry 1 of 2"],
+        ['an empty hostname', '=key1', 'empty server name in the value'],
+        ['an empty key', 'host1=', 'empty key in the value'],
+        ['whitespace in the hostname', 'ho st1=key1', 'whitespace in the server name in the value'],
+        ['whitespace in the key', 'host1=ke y1', 'whitespace in the key in the value'],
+        ['whitespace around a separator', 'host1=key1; host2=key2', 'whitespace in the server name in entry 2 of 2']
+    ])('warns about %s', (_description, rawKey, expectedReason) => {
+        // when
+        expect(DevelocityAccessCredentials.parse(rawKey)).toBeNull()
+
+        // then
+        expect(warnings()).toEqual([
+            `Ignoring badly formed Develocity access key: ${expectedReason}. The expected format is 'server=key[;server=key]*'.`
+        ])
+    })
+
+    it('never includes any part of the access key value in the warning', () => {
+        // when
+        expect(DevelocityAccessCredentials.parse('my-host=my sec ret')).toBeNull()
+
+        // then
+        const message = warnings()[0]
+        expect(message).not.toContain('my-host')
+        expect(message).not.toContain('sec')
+    })
+
+    it('does not warn for a valid access key', () => {
+        // when
+        expect(DevelocityAccessCredentials.parse('host1=key1;host2=key2')).not.toBeNull()
+
+        // then
+        expect(warnings()).toEqual([])
+    })
+
+    it('does not warn for an empty access key', () => {
+        // when
+        expect(DevelocityAccessCredentials.parse('  ')).toBeNull()
+
+        // then
+        expect(warnings()).toEqual([])
+    })
+})

--- a/build-scan-shared/src/auth/short-lived-token.ts
+++ b/build-scan-shared/src/auth/short-lived-token.ts
@@ -124,7 +124,6 @@ type HostnameAccessKey = {
 }
 
 export class DevelocityAccessCredentials {
-    static readonly accessKeyRegexp = /^([^;=\s]+=\w+)(;[^;=\s]+=\w+)*$/
     readonly keys: HostnameAccessKey[]
 
     private constructor(allKeys: HostnameAccessKey[]) {
@@ -137,17 +136,63 @@ export class DevelocityAccessCredentials {
 
     private static readonly keyDelimiter = ';'
     private static readonly hostDelimiter = '='
+    private static readonly whitespace = /\s/
 
+    /**
+     * Parse a `host=key[;host=key]*` access key value.
+     *
+     * Only the structure needed to split the value is validated: entries are separated by `;`, and
+     * each entry is a hostname followed by `=` and a key, where the hostname contains no `=`, `;` or
+     * whitespace, and the key is non-empty and contains no `;` or whitespace. Nothing else is
+     * assumed about the key: it may be an OIDC token containing `.`, `-`, `_` and `=` padding, so
+     * each entry is split on its _first_ `=` only.
+     *
+     * Returns `null` if the value doesn't match, emitting a warning that describes what is wrong.
+     */
     static parse(rawKey: string): DevelocityAccessCredentials | null {
-        if (!this.isValid(rawKey)) {
+        const trimmedKey = rawKey.trim()
+        if (!trimmedKey) {
             return null
         }
-        return new DevelocityAccessCredentials(
-            rawKey.split(this.keyDelimiter).map(hostKey => {
-                const pair = hostKey.split(this.hostDelimiter)
-                return {hostname: pair[0], key: pair[1]}
-            })
+        const keys = new Array<HostnameAccessKey>()
+        const entries = trimmedKey.split(this.keyDelimiter)
+        for (const [index, entry] of entries.entries()) {
+            const separatorIndex = entry.indexOf(this.hostDelimiter)
+            if (separatorIndex === -1) {
+                return this.warnBadlyFormed(index, entries.length, `no '${this.hostDelimiter}' separator`)
+            }
+            const hostname = entry.substring(0, separatorIndex)
+            const key = entry.substring(separatorIndex + 1)
+            if (!hostname) {
+                return this.warnBadlyFormed(index, entries.length, 'empty server name')
+            }
+            if (!key) {
+                return this.warnBadlyFormed(index, entries.length, 'empty key')
+            }
+            if (this.whitespace.test(hostname)) {
+                return this.warnBadlyFormed(index, entries.length, 'whitespace in the server name')
+            }
+            if (this.whitespace.test(key)) {
+                return this.warnBadlyFormed(index, entries.length, 'whitespace in the key')
+            }
+            keys.push({hostname, key})
+        }
+        return new DevelocityAccessCredentials(keys)
+    }
+
+    /**
+     * Warn that an access key value is badly formed and cannot be parsed. Reports only the position
+     * of the offending entry and the reason: the value is a secret, and is not yet registered for
+     * masking at this point, so no part of it is ever included in the message.
+     */
+    private static warnBadlyFormed(index: number, entryCount: number, reason: string): null {
+        const location = entryCount > 1 ? `entry ${index + 1} of ${entryCount}` : 'the value'
+        core.warning(
+            `Ignoring badly formed Develocity access key: ${reason} in ${location}. ` +
+                `The expected format is 'server${this.hostDelimiter}key` +
+                `[${this.keyDelimiter}server${this.hostDelimiter}key]*'.`
         )
+        return null
     }
 
     isEmpty(): boolean {
@@ -158,9 +203,5 @@ export class DevelocityAccessCredentials {
         return this.keys
             .map(k => `${k.hostname}${DevelocityAccessCredentials.hostDelimiter}${k.key}`)
             .join(DevelocityAccessCredentials.keyDelimiter)
-    }
-
-    private static isValid(allKeys: string): boolean {
-        return this.accessKeyRegexp.test(allKeys)
     }
 }


### PR DESCRIPTION
Applies the same fix Daz made in `setup-gradle` ([gradle/actions#1061](https://github.com/gradle/actions/pull/1061)) to `setup-maven` and `setup-npm`.

Fixes [gradle/dv#72981](https://github.com/gradle/dv/issues/72981).

## Problem

Develocity access keys have the format `server=key[;server=key]*`. The short-lived-token code validated that format with:

```
/^([^;=\s]+=\w+)(;[^;=\s]+=\w+)*$/
```

This is too strict about `key`, and an OIDC token value fails it — so Workload Identity cannot be used with these actions today. There were two independent problems:

1. `\w+` rejects the `.`, `-`, `_` and `=` padding a JWT contains.
2. Even had the regex passed, `parse` split each entry with `hostKey.split('=')` and took `pair[1]`, so a key containing `=` would have been **silently truncated** — a worse failure than rejection, since the mangled key would then be sent to the server.

## Change

Drop `accessKeyRegexp` and the separate `isValid` gate; validate structurally in `parse` instead, asserting only what is needed to split the value:

- split on `;`, then split each entry on its **first** `=` only
- hostname: non-empty and free of whitespace (it cannot contain `=` or `;` by construction)
- key: non-empty and free of whitespace — nothing else is assumed about its shape

The class body is taken **verbatim** from the upstream fix, so `build-scan-shared/src/auth/short-lived-token.ts` stays a faithful copy of `gradle/actions`' version and future syncs remain trivial.

The fix lands in `build-scan-shared`, so it covers **`setup-maven`, `setup-npm` and `maven-publish-build-scan`** — the issue only names the first two.

Two small intentional behaviour deltas beyond the fix, same as upstream:

- The whole value is now trimmed, so a trailing newline on a secret no longer rejects the key. Internal whitespace still rejects.
- Empty entries (`host=key;`, `;host=key`) still reject, as before.

## Testing

New `build-scan-shared/__tests__/auth/short-lived-token.test.ts`, ported from the upstream test additions: a JWT-shaped key value, first-separator-only splitting (`host1=a=b==` → key `a=b==`), surrounding-whitespace tolerance, a `raw()` round-trip preserving `==` padding, a table of eleven rejection cases, and the warning messages (asserting no part of the secret ever appears in them).

Also added an end-to-end case to `auth.test.ts` exercising the actual reported failure path through `getAccessToken` — an OIDC-shaped key is now exchanged for a short-lived token, with the token asserted to reach the server intact in the `Authorization` header.

61 tests pass; `npm run check` and `npm run package` are clean. `dist/` is intentionally not committed — `update-dist.yml` regenerates it on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)