### PR TITLE
Fix npm vulnerability in browserslist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4004,6 +4004,19 @@
         }
       ]
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
@@ -4053,9 +4066,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -4073,10 +4086,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001726",
-        "electron-to-chromium": "^1.5.173",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4214,9 +4228,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001731",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
-      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -4636,9 +4650,9 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.194",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.194.tgz",
-      "integrity": "sha512-SdnWJwSUot04UR51I2oPD8kuP2VI37/CADR1OHsFOUzZIvfWJBO6q11k5P/uKNyTT3cdOsnyjkrZ+DDShqYqJA==",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "dev": true,
       "license": "ISC"
     },
@@ -9061,11 +9075,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -11906,9 +11923,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Resolves the two open [Dependabot alerts](https://github.com/gradle/develocity-actions/security/dependabot) — [#98](https://github.com/gradle/develocity-actions/security/dependabot/98) and [#99](https://github.com/gradle/develocity-actions/security/dependabot/99) — both covering `browserslist <= 4.28.6`, high severity, CVSS 7.5:

| Advisory | Summary |
|---|---|
| [GHSA-73wf-gq98-2v4g](https://github.com/advisories/GHSA-73wf-gq98-2v4g) | Uncaught crash / prototype write via untrusted `browserslist-stats.json` custom stats in `normalizeStats()` |
| [GHSA-c83g-rgw3-j3cx](https://github.com/advisories/GHSA-c83g-rgw3-j3cx) | Unbounded memory growth — result cache with no eviction — leading to eventual OOM |

## Severity in context

`browserslist` is a **dev-only transitive** dependency, reached two ways:

```
eslint-plugin-github -> eslint-plugin-escompat -> browserslist
ts-jest -> @babel/core -> @babel/helper-compilation-targets -> browserslist
```

Both vulnerabilities require untrusted input — a custom stats file, or an unbounded stream of distinct queries — neither of which occurs in this repo's lint and test usage. So this is **alert hygiene, not a fix for a reachable exposure**. Rebuilding confirms it: `dist/` comes back byte-identical, so `browserslist` never reaches the shipped action bundles.

## Why no override

Unlike the transitive packages bumped in #215, `browserslist` is **not** pinned by a top-level `overrides` entry — and it doesn't need one. Every parent range already admits the patched version:

| Parent | Declared range | Admits 4.28.7+ |
|---|---|---|
| `@babel/helper-compilation-targets` | `^4.24.0` | ✅ |
| `update-browserslist-db` | `>= 4.21.0` | ✅ |
| `eslint-plugin-escompat` | `^4.23.1` | ✅ |

The lockfile was simply stale at 4.25.1, so `npm update browserslist` suffices. Adding an override would be a permanent pin with nothing to justify it.

## Change

`package-lock.json` only — `browserslist` 4.25.1 → **4.28.8** (past the 4.28.7 patch), carrying its own data dependencies (`caniuse-lite`, `electron-to-chromium`, `node-releases`, `update-browserslist-db`) plus `baseline-browser-mapping`, a new transitive introduced in browserslist 4.28.x. All dev-only.

## Verification

- `npm audit` — 0 vulnerabilities across all severities
- `npm ci` — clean, lockfile consistent
- `npm run all` — green, 61 tests passing
- `dist/` byte-identical after a full rebuild, so nothing to regenerate

🤖 Generated with [Claude Code](https://claude.com/claude-code)