### PR TITLE
Fix npm vulnerability in qs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1150,25 +1150,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -10295,12 +10309,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -10732,14 +10747,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -10751,13 +10766,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "license": "MIT",
   "overrides": {
-    "qs": "^6.15.2",
+    "qs": "^6.16.0",
     "shell-quote": "^1.10.0",
     "brace-expansion": "^5.0.9",
     "undici": "^6.28.0",


### PR DESCRIPTION
Dependabot alert [#100](https://github.com/gradle/develocity-actions/security/dependabot/100) covers `qs` 6.15.2, medium severity, CVSS 3.7:

- **GHSA-x5fp-wj9c-mxmx / CVE-2026-82562**: bracket-key input bypasses `arrayLimit` and `throwOnLimitExceeded` when `comma: true`, so a single parameter can materialize an arbitrarily large array.

`npm audit` flags a second advisory on the same package, not yet raised as a Dependabot alert:

- **GHSA-4mjr-xmp4-gh2g / CVE-2026-82417**: `qs.stringify()` calls `obj.constructor.isBuffer` without checking it is callable, so a value parsed with `plainObjects` or `allowPrototypes` can turn a `parse` -> `stringify` round-trip into an uncaught `TypeError`.

Both are fixed in 6.16.0. `qs` is pinned by a top-level override, so bump it from `^6.15.2` to `^6.16.0`. `typed-rest-client` depends on `qs` at an exact `6.15.3`, which the override supersedes — no dependency change is needed, and `npm audit`'s suggested `--force` remedy (downgrading to `typed-rest-client` 2.3.0) is not applied.

### Reachability

Unlike the transitive packages in the previous vulnerability fixes, `qs` is a runtime dependency: `typed-rest-client` is used as `HttpClient` in `build-scan-shared/src/auth/short-lived-token.ts` to fetch a short-lived Develocity token. That path only issues outbound requests and never parses attacker-supplied query strings, so neither advisory is reachable here. This is alert hygiene rather than a fix for an exposure.

### Also included

`@humanfs/node` 0.16.7 -> 0.16.8 (GHSA-p498-v437-472g, moderate: recursive copy follows symlinks outside the source tree). It is dev-only, reached via `prettier-eslint` -> `eslint`, and its parent range `^0.16.6` already admits the patched version, so `npm update` suffices with no new override. It carries `@humanfs/core` 0.19.2 and the new `@humanfs/types` transitive along with it, both dev-only.

### Verification

- `npm audit` reports 0 vulnerabilities
- `npm ci` is consistent from a clean `node_modules`
- `npm run all` is green, 61 tests passing

Being a runtime dependency, `qs` is bundled into all four `dist` entry points, so `dist` is expected to change. It is left out of this PR and will be regenerated by the `update-dist` workflow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
