### PR TITLE
Update release notes

### DIFF
--- a/release/changelog.md
+++ b/release/changelog.md
@@ -1,8 +1,10 @@
 # 🚀 Improvements
--
+- Update Develocity docs links to docs.develocity.ai (https://github.com/gradle/develocity-actions/pull/209)
 
 # 🐛 Bug fixes
--
+- Relax Develocity access key format validation so the access key is treated as opaque, unblocking Workload Identity / OIDC tokens (https://github.com/gradle/develocity-actions/pull/220)
 
 # 📦 Dependency updates
--
+- develocity-maven-extension:2.5.0
+- undici:6.28.0
+- brace-expansion:5.0.9


### PR DESCRIPTION
Prepares the release notes for **v2.3**, covering the 25 commits since v2.2.

```markdown
# 🚀 Improvements
- Update Develocity docs links to docs.develocity.ai (#209)

# 🐛 Bug fixes
- Relax Develocity access key format validation so the access key is treated as opaque, unblocking Workload Identity / OIDC tokens (#220)

# 📦 Dependency updates
- develocity-maven-extension:2.5.0
- undici:6.28.0
- brace-expansion:5.0.9
```

## What was left out, and why

Following the convention of v2.1/v2.2, only user-facing changes are listed.

- **qs, browserslist, js-yaml, shell-quote** — security bumps (#221, #222, #215), but all four are dev-only and appear in **0 of the 4 `dist/` bundles**, so no released action ever carried them. Listing them would imply an exposure that didn't exist.
- **undici, brace-expansion** — also security bumps (#215), but these *do* ship in **all 4 bundles**, so they're listed.
- **`org.eclipse.sisu.inject` 1.0.0 → 1.1.0** (#212) — an `annotationProcessorPaths` entry, so it never reaches the extension jar.
- **Dependabot npm/github-actions group bumps and `[bot] Update dist directory`** — build tooling and generated output.

Next step after merge: tag `v2.3` and push it, which triggers `release.yml` to publish this file as the release body; then a follow-up PR empties the changelog for the next iteration, per the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)