### PR TITLE
Prepare next development iteration

### DIFF
--- a/release/changelog.md
+++ b/release/changelog.md
@@ -1,10 +1,8 @@
 # 🚀 Improvements
-- Update Develocity docs links to docs.develocity.ai (https://github.com/gradle/develocity-actions/pull/209)
+-
 
 # 🐛 Bug fixes
-- Relax Develocity access key format validation so the access key is treated as opaque, unblocking Workload Identity / OIDC tokens (https://github.com/gradle/develocity-actions/pull/220)
+-
 
 # 📦 Dependency updates
-- develocity-maven-extension:2.5.0
-- undici:6.28.0
-- brace-expansion:5.0.9
+-


### PR DESCRIPTION
Empties `release/changelog.md` now that [v2.3](https://github.com/gradle/develocity-actions/releases/tag/v2.3) is tagged and published, per the [release procedure](https://github.com/gradle/develocity-actions/#release-the-action) in the README.

Restores the file to the same template used after v2.2 (#200) — verified byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)